### PR TITLE
Corrige variável de versão do Quarkus no pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
+                <version>${quarkus.platform.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -37,22 +37,22 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-undertow</artifactId>
-            <version>${quarkus.version}</version>
+            <version>${quarkus.platform.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-jackson</artifactId>
-            <version>${quarkus.version}</version>
+            <version>${quarkus.platform.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jsonp</artifactId>
-            <version>${quarkus.version}</version>
+            <version>${quarkus.platform.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-client</artifactId>
-            <version>${quarkus.version}</version>
+            <version>${quarkus.platform.version}</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
Provavelmente ao gerar o projeto no http://code.quarkus.io ele está gerando com erro.
A variável `${quarkus.version}` que indica o nome da versão do Quarkus
foi renomeada para `${quarkus.platform.version}`, mas o nome antigo
continuou sendo usado.